### PR TITLE
bug/#38 ctr+k algolia search Return URL

### DIFF
--- a/src/server/utils/algolia.ts
+++ b/src/server/utils/algolia.ts
@@ -22,7 +22,7 @@ export const saveToAlgolia = async (post: NotionPost) => {
       .join('');
 
     const records: AlgoliaSearchObjectRequest = {
-      objectID: post.id,
+      objectID: post.slug,
       title: post.title,
       category: post.category.name,
       tags: post.tags.map((tag) => tag.name),

--- a/src/server/utils/algolia.ts
+++ b/src/server/utils/algolia.ts
@@ -7,7 +7,7 @@ const client = algoliasearch(
   `${process.env.ALGOLIA_APPLICATION_ID}`,
   `${process.env.ALGOLIA_ADMIN_API_KEY}`
 );
-const index = client.initIndex('noblog');
+const index = client.initIndex('ECmaker');
 
 export const saveToAlgolia = async (post: NotionPost) => {
   try {

--- a/src/utils/algolia.ts
+++ b/src/utils/algolia.ts
@@ -7,7 +7,7 @@ const client = algoliasearch(
   `${process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY}`
 );
 
-const index = client.initIndex('noblog');
+const index = client.initIndex('ECmaker');
 
 export const searchAlgolia = async (query: string) => {
   const res = await index.search(query, {


### PR DESCRIPTION
 ctr+k algolia search Return URL #38  fix

## Updated
- [slug] saveAlgolia で post 全部を保存している  
  objectIDをslugに変更した。
- src\hooks\apiHooks\useSpotlightActions.ts　で検索queryとの照合、一致URLのリターン

## Memo
- Algoliaのページで確認可能  
  https://dashboard.algolia.com/apps/S8EVF44K6U/indices
- indexSearchでIndexの設定  
  AlgoliaのページのIndicesのフォルダ分けみたいなもの。

