### PR TITLE
fix/#78 #75つづき-ToC-phoneView、#71つづき-横幅が微妙なときに表示が微妙

### DIFF
--- a/app/layout/Layout.tsx
+++ b/app/layout/Layout.tsx
@@ -37,8 +37,12 @@ export const Layout: FC<Props> = ({ children, ...pageProps }) => {
 
   const spotlight = useSpotlight();
   const handleClickSearchButton = () => spotlight.openSpotlight();
+  
+  const showContentsButton = useMemo(() => {
+    return (pathname === '/posts/');
+  }, [pathname]);
 
-  // ここは変更しても変わらない？ src\components\@layouts\Layout.tsx も変更する !U
+  // ここ app\layout\Layout.tsx は変更しても変わらない？ src\components\@layouts\Layout.tsx も変更する !U
 
   return (
     <div className="bg-gray-200">
@@ -71,9 +75,11 @@ export const Layout: FC<Props> = ({ children, ...pageProps }) => {
           <div className="flex items-center mb-2 sb-2 sm:mb-1 sp:mb-1">
             <SearchButton onClick={handleClickSearchButton} />
           </div>
+          {showContentsButton && (
           <div className="md:hidden">
             <ContentsButton onClick={() => setShowTableOfContents(prev => !prev)} />
           </div>
+        )}
         </div>
       </div>
       <main className="relative z-10 mb-40 min-h-[calc(100vh-102px)] w-full bg-gray-200">

--- a/src/components/@layouts/Layout.tsx
+++ b/src/components/@layouts/Layout.tsx
@@ -38,7 +38,13 @@ export const Layout: FC<Props> = ({ children, ...pageProps }) => {
   const spotlight = useSpotlight();
   const handleClickSearchButton = () => spotlight.openSpotlight();
 
-  // app\layout\Layout.tsx も変更する !U
+  const showContentsButton = useMemo(() => {
+    const path = router.asPath;
+    
+    return path.startsWith('/posts/');
+  }, [router.asPath]);
+
+  // ここ src\components\@layouts\Layout.tsx を変更すると変わるが、 app\layout\Layout.tsx も変更する !U
 
   return (
     <div className="bg-gray-200">
@@ -72,11 +78,13 @@ export const Layout: FC<Props> = ({ children, ...pageProps }) => {
           <div className="flex items-center mb-2 sb-2 sm:mb-1 sp:mb-1">
             <SearchButton onClick={handleClickSearchButton} />
           </div>
-          <div className="md:hidden">
-            <ContentsButton
-              onClick={() => setShowTableOfContents((prev) => !prev)}
-            />
-          </div>
+          {showContentsButton && (
+            <div className="md:hidden">
+              <ContentsButton
+                onClick={() => setShowTableOfContents((prev) => !prev)}
+              />
+            </div>
+          )}
         </div>
       </div>
       <main className="relative z-10 mb-40 min-h-[calc(100vh-102px)] w-full bg-gray-200">

--- a/src/components/features/notionBlog/PostListItem/PostListItem.tsx
+++ b/src/components/features/notionBlog/PostListItem/PostListItem.tsx
@@ -18,7 +18,7 @@ export const PostListItem: FC<Props> = ({ post }) => {
  
   return (
     <div
-      className="flex h-24 cursor-pointer items-start gap-5 rounded bg-gray-50 px-5 py-3 shadow transition-transform hover:scale-105 sp:relative md:h-48"
+      className="flex h-24 cursor-pointer items-start gap-5 rounded bg-gray-50 px-5 py-3 shadow transition-transform hover:scale-105 sm:relative md:h-48"
       onClick={() => router.push(`/posts/${expandPost.slug}`)}
     >
       <Image
@@ -27,7 +27,7 @@ export const PostListItem: FC<Props> = ({ post }) => {
         width={256}
         height={192}
         priority
-        className="h-full w-32 rounded-l-md object-cover md:w-64"
+        className="h-full w-20 rounded-l-md object-cover md:w-64"
       />
       <div
         /*icon+tag+Updated,Categoy+Title*/ className="flex-col justify-between w-full"
@@ -37,9 +37,9 @@ export const PostListItem: FC<Props> = ({ post }) => {
         >
           <div /*icon+tag*/ className="flex items-center">
             <div
-              /*icon*/ className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-white shadow sp:absolute sp:-top-2 sp:-left-2 sp:h-9 sp:w-9"
+              /*icon*/ className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-white shadow sm:absolute sm:-top-2 sm:-left-2 sm:h-9 sm:w-9"
             >
-              <div className="pb-1 text-3xl sp:text-base">{meta.icon}</div>
+              <div className="pb-1 text-3xl sm:text-base">{meta.icon}</div>
             </div>
             <div /*tag*/ className="flex flex-wrap gap-1 ml-3">
               {meta.tags.map((tag, index) => (
@@ -53,13 +53,13 @@ export const PostListItem: FC<Props> = ({ post }) => {
             </div>
           </div>
           <div
-            /*Updated,Category*/ className="whitespace-nowrap text-sm justify-between font-bold sp:absolute sp:top-1.5 sp:right-2 sp:text-xs"
+            /*Updated,Category*/ className="whitespace-nowrap text-sm justify-between font-bold sm:absolute sm:top-1.5 sm:right-2 sm:text-xs"
           >
             <div>{meta.updatedAt}</div>
             <div className="font-bold">{meta.category.name}</div>
           </div>
         </div>
-        <h3 className="font-bold line-clamp-2 sp:text-base mt-4">
+        <h3 className="font-bold line-clamp-2 sm:text-base mt-4">
           {meta.title}
         </h3>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,13 +14,9 @@ module.exports = {
     },
     screens: {
       sp: { max: '640px' },
-      // => @media (max-width: 640px) { ... }
-      sm: '640px',
-      // => @media (min-width: 640px) { ... }
-      md: '768px',
-      // => @media (min-width: 768px) { ... }
-      lg: '1024px',
-      // => @media (min-width: 1024px) { ... }
+      sm: { max: '767px' },
+      md: { min: '768px' },
+      lg: { min: '1024px'},
     },
   },
   plugins: [require('@tailwindcss/line-clamp')],


### PR DESCRIPTION
fix/#78

#75 のつづき ToC-スマホ表示続き fix
- ContentsButtonの表示を記事本体[slug]でのみ行うように変更。

#71 のつづき スマホ表示で表示が微妙 fix
- 使用していなかったsm:を再定義
- sm(タブレット)以下で小さく表示するように変更。

#51 のつづき Actions update. buildコメントをグループ化