### PR TITLE
feature/#68 文字色、太文字への対応 fix

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,7 +12,6 @@ import { DefaultSeo } from 'next-seo';
 import { useMemo, useState, useEffect } from 'react';
 import { RecoilRoot } from 'recoil';
 
-
 import {
   BookIcon,
   ExperimentIcon,

--- a/src/components/notion/RichText.tsx
+++ b/src/components/notion/RichText.tsx
@@ -11,6 +11,28 @@ type Props = {
 const codeAnnotationClasses =
   'bg-slate-900 rounded px-2 py-1 mx-2 font-mono text-teal-400';
 
+const colorClasses = {
+  gray: 'text-gray-500',
+  brown: 'text-brown-500',
+  orange: 'text-orange-500',
+  yellow: 'text-yellow-500',
+  green: 'text-green-500',
+  blue: 'text-blue-500',
+  purple: 'text-purple-500',
+  pink: 'text-pink-500',
+  red: 'text-red-500',
+  default: 'text-black',
+  gray_background: 'bg-gray-100',
+  brown_background: 'bg-brown-100',
+  orange_background: 'bg-orange-100',
+  yellow_background: 'bg-yellow-100',
+  green_background: 'bg-green-100',
+  blue_background: 'bg-blue-100',
+  purple_background: 'bg-purple-100',
+  pink_background: 'bg-pink-100',
+  red_background: 'bg-red-100',
+};
+
 /* Notion の Block Object内のrich_textの配列をいい感じに変換する */
 export const RichText: FC<Props> = ({ text, className }) => {
   return (
@@ -29,7 +51,7 @@ export const RichText: FC<Props> = ({ text, className }) => {
                 annotations[param as keyof typeof annotations] === true,
             );
             const key = `${index}`;
-
+            const colorClass = colorClasses[color] || colorClasses.default;
             if (href)
               return (
                 <a
@@ -39,7 +61,7 @@ export const RichText: FC<Props> = ({ text, className }) => {
                   rel="noopener noreferrer"
                   className={clsx(
                     'transition-opacity hover:opacity-50',
-                    color !== 'default' && `notion-${color}`,
+                    colorClass,
                     annotationClasses.includes('bold') && 'font-bold',
                     annotationClasses.includes('italic') && 'font-italic',
                     annotationClasses.includes('underline') && 'underline',
@@ -57,8 +79,7 @@ export const RichText: FC<Props> = ({ text, className }) => {
                 <span
                   key={key}
                   className={clsx(
-                    '',
-                    color !== 'default' && `notion-${color}`,
+                    colorClass,
                     annotationClasses.includes('bold') && 'font-bold',
                     annotationClasses.includes('italic') && 'font-italic',
                     annotationClasses.includes('underline') && 'underline',
@@ -71,7 +92,7 @@ export const RichText: FC<Props> = ({ text, className }) => {
                 </span>
               );
 
-            return textItem.plain_text;
+            return <span key={key} className={colorClass}>{textItem.plain_text}</span>;
           })}
         </>
       )}


### PR DESCRIPTION
feature/#68 文字色、太文字への対応 fix

RichTextコンポーネント修正: Notionリッチテキストの色反映

- `colorClasses`オブジェクト追加、各色に対応するクラス定義
- `text.map`内で`color`プロパティ使用、`clsx`で適用
- `color`が`default`の場合、黒色適用
- 背景色クラス追加、背景色指定時も適切にスタイル適用
- Notionリッチテキストの色と背景色が正しく反映、エラー解消

- 前commitでステージし忘れた_appの空行削除

---

issueより #68

すべて黒色となる。の対応。↑
![image](https://github.com/user-attachments/assets/f7f8f359-7bf1-4a5f-b789-5af11632766c)

参考：https://alpacat.com/posts/easy-notion-blog-v07

一瞬で解決した  
![image](https://github.com/user-attachments/assets/a9e2383d-271a-4c71-ae27-e17f05c906ce)
