### PR TITLE
fix/#68_コードブロックcaptionの修正

### DIFF
--- a/src/components/notion/RichText.tsx
+++ b/src/components/notion/RichText.tsx
@@ -43,9 +43,9 @@ export const RichText: FC<Props> = ({ text, className }) => {
       ) : (
         <>
           {text.map((textItem, index: number) => {
-            const { annotations } = textItem; // アノテーションを取得
-            const { color } = textItem.annotations; // アノテーションの色を取得
-            const { href } = textItem; // リンクを取得
+            const { annotations } = textItem;
+            const { color } = textItem.annotations;
+            const { href } = textItem;
             const annotationClasses = Object.keys(annotations).filter(
               (param) =>
                 annotations[param as keyof typeof annotations] === true,
@@ -62,6 +62,7 @@ export const RichText: FC<Props> = ({ text, className }) => {
                   className={clsx(
                     'transition-opacity hover:opacity-50',
                     colorClass,
+                    className,
                     annotationClasses.includes('bold') && 'font-bold',
                     annotationClasses.includes('italic') && 'font-italic',
                     annotationClasses.includes('underline') && 'underline',
@@ -80,6 +81,7 @@ export const RichText: FC<Props> = ({ text, className }) => {
                   key={key}
                   className={clsx(
                     colorClass,
+                    className,
                     annotationClasses.includes('bold') && 'font-bold',
                     annotationClasses.includes('italic') && 'font-italic',
                     annotationClasses.includes('underline') && 'underline',
@@ -92,7 +94,7 @@ export const RichText: FC<Props> = ({ text, className }) => {
                 </span>
               );
 
-            return <span key={key} className={colorClass}>{textItem.plain_text}</span>;
+            return <span key={key} className={clsx(colorClass, className)}>{textItem.plain_text}</span>;
           })}
         </>
       )}

--- a/src/components/notion/blocks/Code/Code.tsx
+++ b/src/components/notion/blocks/Code/Code.tsx
@@ -38,7 +38,7 @@ export const Code: FC<Props> = ({ block }: Props) => {
       </Prism>
       {block.code.caption.length > 0 && (
         <div className="-mt-1 rounded-b-md bg-slate-800 px-4 pb-2 pt-3 text-xs text-slate-200">
-          <RichText text={block.code.caption} />
+          <RichText text={block.code.caption} className="text-slate-200" />
         </div>
       )}
     </div>


### PR DESCRIPTION
#68 つづき fix

RichTextコンポーネントのスタイル適用を修正

- captionの色が変わらない問題を解決するため、RichTextコンポーネントにclassNameを適切に適用。
- clsx関数を使用して、渡されたclassNameが各要素に正しく反映されるように修正。
- text-slate-200クラスがcaptionに適用されることを確認。
- もし問題が続く場合は、CSSの優先順位や他のスタイルの影響を再確認。