### PR TITLE
fix/#94 ISR to SSG 検討 → 中止

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,7 +35,6 @@ export const getStaticProps = async () => {
     props: {
       posts: results as NotionPageObjectResponse[],
     },
-    revalidate: 1, //[s] added ISR.
   };
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,6 +35,7 @@ export const getStaticProps = async () => {
     props: {
       posts: results as NotionPageObjectResponse[],
     },
+    revalidate: 61, //[s] added ISR.
   };
 };
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -50,7 +50,6 @@ export const getStaticProps = async (context: { params: Params }) => {
     props: {
       post,
     },
-    revalidate: 1, //[s] added ISR.
   };
 };
 

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -50,6 +50,7 @@ export const getStaticProps = async (context: { params: Params }) => {
     props: {
       post,
     },
+    revalidate: 61, //[s] added ISR.
   };
 };
 

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -45,7 +45,6 @@ export const getStaticProps = async () => {
       postsArray,
       properties,
     },
-    revalidate: 1, //[s] added ISR.
   };
 };
 

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -45,6 +45,7 @@ export const getStaticProps = async () => {
       postsArray,
       properties,
     },
+    revalidate: 61, //[s] added ISR.
   };
 };
 


### PR DESCRIPTION
fix/#94 ISR to SSG fix.

ssgへの変更を検討

# 結論
現状維持、ISRのコード(revalidate) を保持する。  
検討の結果、コードのrevalidateを消してssgにしても応答性は大差なし。 2bebb53     

それ以前に、おそらく現状がISRで機能していない。SSGの動作になっているっぽい。  
notionを更新しても更新されないし。。  
サーバーの設定がうまく出来ていないと思われる。  

まあ、Actionsで30分毎にbuildしているので、SSGの動作になっていても問題ないと判断する。  
コードはssgにしておいても良いが、一応ISRのコード(現状のまま)としておく。

revalidate 61sに変えてもISRの挙動にならず、SSGの挙動のまま変化なかった。 03929a8  
(Notion更新しても変更されず。)  


---

# 検討
## 検討結果 SSG
https://671af35492b34ba20bc1e349--blog-ecmaker.netlify.app/posts/Notion-Block-Preview
- 文字色previewページ  
  3回目900ms
  ![image](https://github.com/user-attachments/assets/0e0914f7-c13b-4825-a957-dfb787e41d33)

- block previewページ
  3回目 3000ms  切る   
  ![image](https://github.com/user-attachments/assets/9239cda2-87f1-4481-9351-27d170554b14)



## 現状 ISR (の設定をしたつもりだがSSGになっている(?))  
https://6719f2cb37025880c025702c--blog-ecmaker.netlify.app/posts/Notion-Block-Preview
- 文字色previewページ  
  3回目900ms
  ![image](https://github.com/user-attachments/assets/9e26e4c0-8103-49ea-b8fb-7a7b0845a769)
- block previewページ
  3回目 3400ms     
  ![image](https://github.com/user-attachments/assets/9696e10d-8a5e-41b5-9cb8-c287f393ae0f)
  2700msのときも   
  ![image](https://github.com/user-attachments/assets/67c7cbe8-859d-4d87-a757-c357040d54a5)



