### PR TITLE
feat(adsense): Implement AdSense component with test mode support

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,11 +6,9 @@ export default function Document() {
   return (
     <Html lang="ja-JP" className="scroll-smooth">
       <Head>
-        <script
-          async
-          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_ADSENSE_ID}`}
-          crossOrigin="anonymous"
-        />
+        {/* Google AdSense メタタグの追加 */}
+        <meta name="google-adsense-account" content={process.env.NEXT_PUBLIC_ADSENSE_ID} />
+        {/* メタタグのここまで */}
       </Head>
       <body>
         {/* Google Tag Manager (noscript) */}
@@ -28,6 +26,10 @@ export default function Document() {
         {/* End Google Tag Manager (noscript) */}
         <Main />
         <NextScript />
+        {/* Google AdSense スクリプトの追加 */}
+        <script async src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_ADSENSE_ID}`}
+          crossOrigin="anonymous"></script>
+        {/* スクリプトのここまで */}
       </body>
     </Html>
   );

--- a/src/components/@templates/PostDetailTemplate.tsx
+++ b/src/components/@templates/PostDetailTemplate.tsx
@@ -6,6 +6,7 @@ import type {
 } from '~/types/notion';
 
 import { Bio } from '~/commons/Bio';
+import { AdSense } from '~/components/features/adsense/AdSense';
 import { useTableOfContentsContext } from '~/components/features/notionBlog/TableOfContentsContext';
 import { CommentForm } from '~/features/notionBlog/CommentForm';
 import { Comments } from '~/features/notionBlog/Comments';
@@ -40,6 +41,19 @@ export const PostDetailTemplate: FC<Props> = ({ post, comments, onSubmit }) => {
 
         <div className="w-aside">
           <div className="sticky top-[112px] space-y-4">
+            {/* スクエア広告の<!-- サイドバー -->部分 */}
+            <div className="bg-white p-2 rounded-lg shadow">
+              <AdSense
+                slot="7515574692"
+                testMode={process.env.NODE_ENV === 'development'}
+                style={{
+                  display: 'block',
+                  width: '300px',
+                  height: '250px',
+                  margin: '0 auto',
+                }}
+              />
+            </div>
             <TableOfContents blocks={post.children} />
             <PostMeta meta={post} commentCount={comments.length} />
             <Bio />

--- a/src/components/features/adsense/AdSense.tsx
+++ b/src/components/features/adsense/AdSense.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+declare global {
+  interface Window {
+    adsbygoogle: any[];
+  }
+}
+
+type Props = {
+  slot: string;
+  style?: React.CSSProperties;
+  format?: string;
+  responsive?: boolean;
+  testMode?: boolean;
+};
+
+export const AdSense: React.FC<Props> = ({
+  slot,
+  style = { display: 'block', width: '300px', height: '250px' },
+  format = 'auto',
+  responsive = true,
+  testMode = false,
+}) => {
+  useEffect(() => {
+    try {
+      const pushAd = () => {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+      };
+      
+      if (document.readyState === 'complete') {
+        pushAd();
+      } else {
+        window.addEventListener('load', pushAd);
+
+        return () => window.removeEventListener('load', pushAd);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('AdSense error:', err);
+    }
+  }, []);
+
+  return (
+    <div className="min-h-[250px]">
+      <ins
+        className="adsbygoogle"
+        style={style}
+        data-ad-client={`ca-pub-${process.env.NEXT_PUBLIC_ADSENSE_ID}`}
+        data-ad-slot={slot}
+        data-ad-format={format}
+        data-full-width-responsive={responsive}
+        data-ad-test={testMode ? 'on' : undefined}
+      />
+    </div>
+  );
+}; 


### PR DESCRIPTION
広告表示機能の実装とテストモード対応

## updated
- AdSenseコンポーネントの新規作成
  - 広告表示用の共通コンポーネントを実装
  - テストモード対応のフラグを追加
  - 型定義の追加とエラーハンドリングの実装
- 広告表示の最適化
  - サイズを明示的に指定(300x250px)
  - 最小高さの確保によるレイアウト崩れ防止
  - 広告読み込みタイミングの調整
- PostDetailTemplateの改善
  - AdSenseコンポーネントの統合
  - 広告表示用のコンテナスタイル追加
  - 背景色と余白の調整による視認性向上
- 環境変数対応
  - NEXT_PUBLIC_ADSENSE_IDの利用
  - 開発環境でのテストモード自動有効化

## branch
feature/#52_googleAd

## ToDo
- googleAdサイトでの確認・再申請